### PR TITLE
#60: Scratch away an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ Now you can use the component in your markup:
 | Slot name | Description |
 |-----------|-------------|
 | default | The content to be scratched free. |
+| scratch-source | Used to pass an image that acts as a scratch-color replacement. |
+
+Example on how to use the `scratch-source` slot:
+
+```html
+<wc-scratch>
+  <h1>Scratch me!</h1>
+  <img slot="scratch-source" crossorigin style="display: none;" src="https://example.com/example.jpeg" alt="image" />
+</wc-scratch>
+```
+
+- To get the best experience make sure that your content is the same size as the image used to hide it.
+- You need to set `display: none` on this image so the original is getting hidden. We only read its image data and paint it on the canvas.
+- For images fetched over the internet you also need to set `crossorigin` if you want to use the `percentage-update` feature or else the `CanvasRenderingContext2D: getImageData()` will throw an error.
 
 ### 💡 Props
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
       <wc-scratch brush-size="100" scratch-color="pink">
         <img src="https://images.unsplash.com/photo-1451772741724-d20990422508?q=80&w=870&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="image" />
       </wc-scratch>
+      <wc-scratch brush-size="20">
+        <div style="width: 300px; height: 450px; background-color: aqua;">
+          <h1>Scratch me!</h1>
+        </div>
+        <img slot="scratch-source" crossorigin style="display: none;" src="https://images.unsplash.com/photo-1711619034404-665a4bc6dcd3?q=80&w=300&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" alt="image" />
+      </wc-scratch>
     </main>
     <script type="module" src="/src/scratch/scratch.ts"></script>
     <script>

--- a/test/scratch.test.ts
+++ b/test/scratch.test.ts
@@ -270,4 +270,19 @@ describe('wc-scratch', () => {
     expect(calcSpy).toBeCalledTimes(param ? 1 : 0)
     if (param) expect(calcSpy).toHaveBeenCalledWith(ScratchEvents.PERCENTAGE_UPDATE, 100)
   })
+
+  it.each([false, true])('sets the scratch source image element when set: %s', async (param) => {
+    // Arrange
+    document.body.innerHTML = param
+      ? '<wc-scratch percentage-update><p>Scratch!</p><img slot="scratch-source" src="any" /></wc-scratch>'
+      : '<wc-scratch><p>Scratch!</p></wc-scratch>'
+    const comp = document.querySelector('wc-scratch') as Scratch
+
+    // Act & Assert
+    if (param) {
+      expect(comp.scratchSourceImage).toBeInstanceOf(HTMLImageElement)
+    } else {
+      expect(comp.scratchSourceImage).toBeNull()
+    }
+  })
 })


### PR DESCRIPTION
Add ability to pass an image into a named slot that will be used to replace the `scratch-color`